### PR TITLE
Add --lineout option to produce line-oriented output

### DIFF
--- a/lpmadison.py
+++ b/lpmadison.py
@@ -58,16 +58,18 @@ def parse_repo(args):
         #     "YYYY-MM-DD"
         # ):
 
-        print(
-            f"Package: '{p.source_package_name}'\n"
-            f"\tVersion: '{p.source_package_version}'\n"
-            f"\tPublished: '{p.date_published}'\n"
-            f"\tDays ago: {delta.in_days()}"
-        )
-        # f"\tURLs: '{p.binaryFileUrls()}\n"
-
-        for u in p.binaryFileUrls():
-            print(f"\t{u}\n")
+        if args.lineout:
+            print( f"{p.date_published} {p.source_package_name} {p.source_package_version} {p.binaryFileUrls()}")
+        else:
+            print(
+                f"Package: '{p.source_package_name}'\n"
+                f"\tVersion: '{p.source_package_version}'\n"
+                f"\tPublished: '{p.date_published}'\n"
+                f"\tDays ago: {delta.in_days()}"
+            )
+            # f"\tURLs: '{p.binaryFileUrls()}\n"
+            for u in p.binaryFileUrls():
+                print(f"\t{u}\n")
 
 
 def parse_publish_date(args, foo):
@@ -89,6 +91,7 @@ def parse_args():
     parser.add_argument("--date", help="Search packages published on <date>")
     parser.add_argument("--before", help="Search packages published before <date>")
     parser.add_argument("--after", help="Search packages published after <date>")
+    parser.add_argument('--lineout', action=argparse.BooleanOptionalAction, help="Produce line-oriented output instead of the default stanza-oriented output")
 
     return parser.parse_args()
 


### PR DESCRIPTION
The default output is stanza-based. This can be used for post-processing, but a
line-oriented output may also be desirable for post-processing of the output.

This change adds a boolean option --lineout which defaults to false, in which
case the original stanza-based output is produced.

If the option is specified, then a single line per record is output. Notes that
I removed the days-since from this since I found that running the command on
different days and comparing the output produced spurious differences on every
line as time marched on. 

Also note that I tried to simply use the {p.binaryFileUrls()} syntax for the
p.binaryUrls() array as suggested in the comment above the existing for loop
and it produced acceptable line-oriented output for it, although I did not have
any examples of multiple items in the array to full test. Also, I moved the date
to be the first field in each line since it provides the primary sort key.

Line-oriented output:

lpmadison.py --series focal --arch amd64 --package samba --lineout
2023-08-18 06:18:41.803161+00:00 samba 2:4.15.13+dfsg-0ubuntu0.20.04.4 ['https://launchpad.net/ubuntu/+archive/primary/+files/samba_4.15.13+dfsg-0ubuntu0.20.04.4_amd64.deb']
2023-08-18 00:29:03.302092+00:00 samba 2:4.15.13+dfsg-0ubuntu0.20.04.4 ['https://launchpad.net/ubuntu/+archive/primary/+files/samba_4.15.13+dfsg-0ubuntu0.20.04.4_amd64.deb']
2023-08-17 18:19:22.165915+00:00 samba 2:4.15.13+dfsg-0ubuntu0.20.04.4 ['https://launchpad.net/ubuntu/+archive/primary/+files/samba_4.15.13+dfsg-0ubuntu0.20.04.4_amd64.deb']
...

Stanza-oriented output:

lpmadison.py --series focal --arch amd64 --package samba
Package: 'samba'
	Version: '2:4.15.13+dfsg-0ubuntu0.20.04.4'
	Published: '2023-08-18 06:18:41.803161+00:00'
	Days ago: 0
	https://launchpad.net/ubuntu/+archive/primary/+files/samba_4.15.13+dfsg-0ubuntu0.20.04.4_amd64.deb

Package: 'samba'
	Version: '2:4.15.13+dfsg-0ubuntu0.20.04.4'
	Published: '2023-08-18 00:29:03.302092+00:00'
	Days ago: 0
	https://launchpad.net/ubuntu/+archive/primary/+files/samba_4.15.13+dfsg-0ubuntu0.20.04.4_amd64.deb

Package: 'samba'
	Version: '2:4.15.13+dfsg-0ubuntu0.20.04.4'
	Published: '2023-08-17 18:19:22.165915+00:00'
	Days ago: 1
	https://launchpad.net/ubuntu/+archive/primary/+files/samba_4.15.13+dfsg-0ubuntu0.20.04.4_amd64.deb
...
